### PR TITLE
feat(auth): finish authentication using jwt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,32 @@
 			<version>3.0.0</version>
 		</dependency>
 
+<!--		This is for auth & security file-->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/telu/schoolmanagement/auth/controller/AuthController.java
+++ b/src/main/java/com/telu/schoolmanagement/auth/controller/AuthController.java
@@ -1,0 +1,49 @@
+package com.telu.schoolmanagement.auth.controller;
+
+import com.telu.schoolmanagement.auth.dto.AuthResponse;
+import com.telu.schoolmanagement.auth.dto.LoginRequest;
+import com.telu.schoolmanagement.auth.dto.RegisterRequest;
+import com.telu.schoolmanagement.auth.service.AuthService;
+import com.telu.schoolmanagement.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+        name = "Authentication",
+        description = "Endpoints for user authentication such as login and registration."
+)
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    @Autowired
+    private AuthService authService;
+
+    @Operation(
+            summary = "User Login",
+            description = "Login using NIP (employee ID) and password. Returns a JWT token and User Data if authentication is successful."
+    )
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<AuthResponse>> login(@RequestBody @Valid LoginRequest request) {
+        AuthResponse result = authService.login(request);
+        return ResponseEntity.ok(new ApiResponse<>(true, "success", result));
+    }
+
+    @Operation(
+            summary = "User Registration",
+            description = "Register a new user account. Returns a JWT token and User Data upon successful registration."
+    )
+    @PostMapping("/register")
+    public ResponseEntity<ApiResponse<AuthResponse>> register(@RequestBody RegisterRequest request) {
+        AuthResponse result = authService.register(request);
+        return ResponseEntity.ok(new ApiResponse<>(true, "success", result));
+    }
+}
+

--- a/src/main/java/com/telu/schoolmanagement/auth/dto/AuthResponse.java
+++ b/src/main/java/com/telu/schoolmanagement/auth/dto/AuthResponse.java
@@ -1,0 +1,13 @@
+package com.telu.schoolmanagement.auth.dto;
+
+import com.telu.schoolmanagement.users.dto.UsersResponseDTO;
+import lombok.*;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AuthResponse {
+    private String token;
+    private UsersResponseDTO user;
+}

--- a/src/main/java/com/telu/schoolmanagement/auth/dto/LoginRequest.java
+++ b/src/main/java/com/telu/schoolmanagement/auth/dto/LoginRequest.java
@@ -1,0 +1,20 @@
+package com.telu.schoolmanagement.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginRequest {
+
+    @NotBlank(message = "Nip Users cannot be blank")
+    @Size(max = 15,  message = "Max Nip is 15 characters")
+    private String nip;
+
+    @NotBlank(message = "Password Users cannot be blank")
+    private String password;
+}

--- a/src/main/java/com/telu/schoolmanagement/auth/dto/RegisterRequest.java
+++ b/src/main/java/com/telu/schoolmanagement/auth/dto/RegisterRequest.java
@@ -1,0 +1,36 @@
+package com.telu.schoolmanagement.auth.dto;
+
+import jakarta.persistence.Column;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RegisterRequest {
+
+    @NotBlank(message = "Nip Users cannot be blank")
+    @Size(max = 20,  message = "Max Nip is 20 characters")
+    private String nip;
+
+    @NotBlank(message = "Password Users cannot be blank")
+    private String password;
+
+    @NotBlank(message = "Name Users cannot be blank")
+    private String name;
+
+    // Role, Program
+    @Column(name = "role_id", nullable = false)
+    private Long roleId;
+
+    private Boolean isActive;
+    private LocalDate graduateAt;
+    private Long createdBy;
+    private Long updatedBy;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/telu/schoolmanagement/auth/dto/RegisterRequest.java
+++ b/src/main/java/com/telu/schoolmanagement/auth/dto/RegisterRequest.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 public class RegisterRequest {
 
     @NotBlank(message = "Nip Users cannot be blank")
-    @Size(max = 20,  message = "Max Nip is 20 characters")
+    @Size(max = 15,  message = "Max Nip is 15 characters")
     private String nip;
 
     @NotBlank(message = "Password Users cannot be blank")
@@ -31,6 +31,4 @@ public class RegisterRequest {
     private LocalDate graduateAt;
     private Long createdBy;
     private Long updatedBy;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/telu/schoolmanagement/auth/service/AuthService.java
+++ b/src/main/java/com/telu/schoolmanagement/auth/service/AuthService.java
@@ -33,7 +33,6 @@ public class AuthService {
 
     public AuthResponse login(LoginRequest request) {
 
-        System.out.println("hash password " + passwordEncoder.encode(request.getPassword()));
         authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(
                         request.getNip(),

--- a/src/main/java/com/telu/schoolmanagement/auth/service/AuthService.java
+++ b/src/main/java/com/telu/schoolmanagement/auth/service/AuthService.java
@@ -1,0 +1,74 @@
+package com.telu.schoolmanagement.auth.service;
+
+import com.telu.schoolmanagement.auth.dto.AuthResponse;
+import com.telu.schoolmanagement.auth.dto.LoginRequest;
+import com.telu.schoolmanagement.auth.dto.RegisterRequest;
+import com.telu.schoolmanagement.common.security.jwt.JWTConfig;
+import com.telu.schoolmanagement.roles.model.Roles;
+import com.telu.schoolmanagement.users.mapper.UsersMapper;
+import com.telu.schoolmanagement.users.model.Users;
+import com.telu.schoolmanagement.users.repository.UsersRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+public class AuthService {
+
+    @Autowired
+    UsersRepository usersRepository;
+
+    @Autowired
+    JWTConfig jwtConfig;
+
+    @Autowired
+    AuthenticationManager authenticationManager;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    public AuthResponse login(LoginRequest request) {
+
+        System.out.println("hash password " + passwordEncoder.encode(request.getPassword()));
+        authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(
+                        request.getNip(),
+                        request.getPassword()
+                )
+        );
+
+        var user = usersRepository.getUsersByNip(request.getNip())
+                .orElseThrow();
+        var jwt = jwtConfig.generateToken(user);
+
+        return AuthResponse.builder()
+                .token(jwt)
+                .user(UsersMapper.toDTO(user))
+                .build();
+    }
+
+    public AuthResponse register(RegisterRequest request) {
+        var user = Users.builder()
+                .nip(request.getNip())
+                .name(request.getName())
+                .isActive(request.getIsActive())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .createdAt(LocalDateTime.now())
+                .role(Roles.builder().id(request.getRoleId()).build())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        usersRepository.save(user);
+
+        var jwt = jwtConfig.generateToken(user);
+        return AuthResponse.builder()
+                .token(jwt)
+                .user(UsersMapper.toDTO(user))
+                .build();
+    }
+
+}

--- a/src/main/java/com/telu/schoolmanagement/common/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/telu/schoolmanagement/common/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,37 @@
+package com.telu.schoolmanagement.common.security;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException)
+            throws IOException {
+
+        String formattedNow = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
+
+        Map<String, Object> error = new HashMap<>();
+        error.put("success", false);
+        error.put("message", "Forbidden. You don't have permission to access this resource");
+        error.put("timeStamp", formattedNow);
+        error.put("path", request.getRequestURI());
+
+        response.setContentType("application/json");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        new ObjectMapper().writeValue(response.getOutputStream(), error);
+    }
+}

--- a/src/main/java/com/telu/schoolmanagement/common/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/telu/schoolmanagement/common/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,38 @@
+package com.telu.schoolmanagement.common.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+            throws IOException {
+
+        String formattedNow = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
+
+        Map<String, Object> error = new HashMap<>();
+        error.put("success", false);
+        error.put("message", "Unauthorized access. Please login first.");
+        error.put("timeStamp", formattedNow);
+        error.put("path", request.getRequestURI());
+
+        response.setContentType("application/json");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        new ObjectMapper().writeValue(response.getOutputStream(), error);
+    }
+}
+
+

--- a/src/main/java/com/telu/schoolmanagement/common/security/CustomUserDetailService.java
+++ b/src/main/java/com/telu/schoolmanagement/common/security/CustomUserDetailService.java
@@ -1,0 +1,30 @@
+package com.telu.schoolmanagement.common.security;
+
+import com.telu.schoolmanagement.users.model.Users;
+import com.telu.schoolmanagement.users.repository.UsersRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.core.userdetails.User.UserBuilder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final UsersRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Users user = userRepository.getUsersByNip(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        UserBuilder builder = org.springframework.security.core.userdetails.User
+                .withUsername(user.getNip());
+        builder.password(user.getPassword());
+//        builder.roles(user.getRole().getName()); // ROLE_ADMIN, ROLE_USER, dll
+
+        return builder.build();
+    }
+}

--- a/src/main/java/com/telu/schoolmanagement/common/security/SecurityConfig.java
+++ b/src/main/java/com/telu/schoolmanagement/common/security/SecurityConfig.java
@@ -1,0 +1,74 @@
+package com.telu.schoolmanagement.common.security;
+
+import com.telu.schoolmanagement.common.security.jwt.filter.JWTAuthFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JWTAuthFilter jwtAuthFilter;
+    private final UserDetailsService userDetailsService;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                   CustomAuthenticationEntryPoint authenticationEntryPoint,
+                                                   CustomAccessDeniedHandler accessDeniedHandler) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/auth/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler)
+                )
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authenticationProvider(authenticationProvider())
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+
+
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(userDetailsService);
+        provider.setPasswordEncoder(passwordEncoder());
+        return provider;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+}
+

--- a/src/main/java/com/telu/schoolmanagement/common/security/jwt/JWTConfig.java
+++ b/src/main/java/com/telu/schoolmanagement/common/security/jwt/JWTConfig.java
@@ -1,0 +1,70 @@
+package com.telu.schoolmanagement.common.security.jwt;
+
+import com.telu.schoolmanagement.users.model.Users;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Service;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+@Service
+public class JWTConfig {
+
+    private static final long EXPIRATION_TIME = 1000 * 60 * 60 * 24; // 24 jam
+    private static final String SECRET_KEY = "telluu_super_secret_jwt_key_for_demo123!@#";
+
+    private Key getSignInKey() {
+        return Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
+    }
+
+    public String extractUsername(String token) {
+        return extractClaim(token, Claims::getSubject);
+    }
+
+    public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
+        final Claims claims = extractAllClaims(token);
+        return claimsResolver.apply(claims);
+    }
+
+    public String generateToken(Users user) {
+        return generateToken(new HashMap<>(), user);
+    }
+
+    public String generateToken(Map<String, Object> extraClaims, Users user) {
+        return Jwts.builder()
+                .setClaims(extraClaims)
+                .setSubject(user.getNip())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
+                .signWith(getSignInKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public boolean isTokenValid(String token, UserDetails userDetails) {
+        final String username = extractUsername(token);
+        return (username.equals(userDetails.getUsername())) && !isTokenExpired(token);
+    }
+
+    private boolean isTokenExpired(String token) {
+        return extractExpiration(token).before(new Date());
+    }
+
+    private Date extractExpiration(String token) {
+        return extractClaim(token, Claims::getExpiration);
+    }
+
+    private Claims extractAllClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSignInKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/java/com/telu/schoolmanagement/common/security/jwt/filter/JWTAuthFilter.java
+++ b/src/main/java/com/telu/schoolmanagement/common/security/jwt/filter/JWTAuthFilter.java
@@ -1,0 +1,58 @@
+package com.telu.schoolmanagement.common.security.jwt.filter;
+
+import com.telu.schoolmanagement.common.security.jwt.JWTConfig;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JWTAuthFilter extends OncePerRequestFilter {
+
+    private final JWTConfig jwtConfig;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        final String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        final String jwt = authHeader.substring(7);
+        final String username = jwtConfig.extractUsername(jwt);
+
+        if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+            if (jwtConfig.isTokenValid(jwt, userDetails)) {
+                UsernamePasswordAuthenticationToken authToken =
+                        new UsernamePasswordAuthenticationToken(
+                                userDetails,
+                                null,
+                                userDetails.getAuthorities()
+                        );
+
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/telu/schoolmanagement/common/swagger/SwaggerConfig.java
+++ b/src/main/java/com/telu/schoolmanagement/common/swagger/SwaggerConfig.java
@@ -1,0 +1,33 @@
+package com.telu.schoolmanagement.common.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        final String securitySchemeName = "Authorization";
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("School Management API")
+                        .version("v1")
+                        .description("Documentation for School Management System"))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName, new SecurityScheme()
+                                .name(securitySchemeName)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER))
+                );
+    }
+}


### PR DESCRIPTION
- handle login and register
- using JWT as token authorized
- using custom exception to catch 403 and 401
- adding swagger config

Swagger documentation update

- first login using swagger and copy token from response
![Screenshot 2025-05-20 104926](https://github.com/user-attachments/assets/21b03bc9-507a-42f5-a8a8-b12236308efa)

![Screenshot 2025-05-20 104903](https://github.com/user-attachments/assets/19267986-29d6-4b87-a91c-8df5b0e70aa3)

- put your token into authorization ( the button is on top right )

![Screenshot 2025-05-20 105035](https://github.com/user-attachments/assets/a1d1a9d5-4c1c-4d73-9098-87dbadb4e1a6)

after that, you can access all endpoint that use authorization
